### PR TITLE
added progress bar, functionable with fixations and saccades

### DIFF
--- a/test.py
+++ b/test.py
@@ -1,0 +1,8 @@
+import numpy as np
+
+fixations = [[1,2,9,8,7], [3,4,2,3,4], [5,6,5,6,7]]
+fixations = np.array(fixations)
+x = fixations[0, 0:3]
+y = fixations[0:2, 1]
+
+print(x)


### PR DESCRIPTION
the only thing that isnt optimized is that if  show and hide fixations is checked and unchecked, then rechecked, it shows all fixations and doesn't correspond with the progress bar. to fix that you just need to touch the progress bar. it is a very very minor issue that does not matter and not worth the time given the time contraints we are on so I will live with it. other than that, the progress bar works as intended!