### PR TITLE
Add a ColorBlindAssist Button

### DIFF
--- a/src/fix8.py
+++ b/src/fix8.py
@@ -1403,7 +1403,7 @@ class Fix8(QMainWindow):
         self.button_fixation_color.setEnabled(False)
         self.button_saccade_color.setEnabled(False)
 
-        self.button_coloblind_assist = QPushButton("Colorblind Assit")
+        self.button_coloblind_assist = QPushButton("Colorblind Assist")
         self.button_coloblind_assist.clicked.connect(self.colorblind_assist)
         self.button_coloblind_assist.setEnabled(False)
         


### PR DESCRIPTION
**What?**
I've added a button in toolbar to allow the user to switch to colorblind assistance mode and switch back.

**Why?**
The colorblind friendly mode is essentially to promote inclusivity and user usability.

**How?**
I've added one function to control the color and add one button to connect to this function.
I used this website as the reference. 
https://davidmathlogic.com/colorblind/#%23D81B60-%231E88E5-%23FFC107-%23004D40
If the color doesn't work well this time, I am welcome to pick another set of color to test.
