### PR TITLE
Remove unneeded icons

### DIFF
--- a/src/fix8.py
+++ b/src/fix8.py
@@ -1244,6 +1244,21 @@ class Fix8(QMainWindow):
 
         # this is needed to remove the coodinates next to the navigation panel when hovering over canvas 
         class Toolbar(NavigationToolBar):
+            def __init__(self, canvas, parent):
+                super().__init__(canvas, parent)
+
+                # Remove unwanted default actions
+                self.removeUnwantedActions()
+
+            def removeUnwantedActions(self):
+                # List of action names/icons to be kept
+                wanted_actions = ['Home', 'Pan', 'Zoom', 'Save']  # Adjust as needed
+
+                # Iterate through existing actions and remove unwanted ones
+                for action in self.actions():
+                    if action.text() not in wanted_actions:
+                        self.removeAction(action)
+
             def set_message(self, s):
                 pass
 


### PR DESCRIPTION
**What?**
Remove three unneeded icons and only keep 'Home', 'Pan', 'Zoom', and 'Save' for the NavigationToolBar.

**Why?**
Avoid the confusion for the users caused by the unneeded icons.
 
**How?**
Add a function to remove the unneeded icons in Toolbar subclass (which is originally using the default setting of NavigationToolBar from matplotlib).